### PR TITLE
feature: auto detect location of RustDesk.exe.

### DIFF
--- a/RustDesk_ID_Changer.bat
+++ b/RustDesk_ID_Changer.bat
@@ -13,9 +13,21 @@ goto :eof
 ::===============================================================================================================
 :Main
 cls
-if exist "C:\Program Files\RustDesk\rustdesk.exe" (
-cd "C:\Program Files\RustDesk\"
-for /f "delims=" %%i in ('rustdesk.exe --get-id ^| more') do set rustdesk_id=%%i
+set rustdesk_loc="C:\Program Files\RustDesk"
+for %%i in (
+    "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RustDesk"
+    "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RustDesk"
+    "HKLM\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\RustDesk"
+) do (
+    for /f "tokens=2*" %%a in ('reg query "%%i" /v "InstallLocation" 2^>nul') do (
+        set rustdesk_loc=%%b
+        goto :Main-found
+    )
+)
+:Main-found
+if exist "%rustdesk_loc%\rustdesk.exe" (
+cd "%rustdesk_loc%"
+for /f "delims=" %%i in ('"%rustdesk_loc%\rustdesk.exe" --get-id ^| more') do set rustdesk_id=%%i
 goto :Run
 ) else (
 echo.
@@ -64,7 +76,7 @@ echo $newContent = $fileContent -replace [regex]::Escape($id), $newId >> RustDes
 echo $newContent ^| Set-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_Host.ps1
 echo Restart-Service RustDesk >> RustDesk_ID_Host.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_ID_Host.ps1
-start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
+start "" "%rustdesk_loc%\rustdesk.exe" --tray
 goto :done
 ::===============================================================================================================
 :ID_Random
@@ -81,7 +93,7 @@ echo $newContent = $fileContent -replace [regex]::Escape($id), $newId >> RustDes
 echo $newContent ^| Set-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_Random.ps1
 echo Restart-Service RustDesk >> RustDesk_ID_Random.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_ID_Random.ps1
-start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
+start "" "%rustdesk_loc%\rustdesk.exe" --tray
 goto :done
 ::===============================================================================================================
 :ID_UserDefined
@@ -101,7 +113,7 @@ echo $newContent = $fileContent -replace [regex]::Escape($id), $newId >> RustDes
 echo $newContent ^| Set-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_UserDefined.ps1
 echo Restart-Service RustDesk >> RustDesk_ID_UserDefined.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_ID_UserDefined.ps1
-start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
+start "" "%rustdesk_loc%\rustdesk.exe" --tray
 goto :done
 ::===============================================================================================================
 :done


### PR DESCRIPTION
Query the location of RustDesk from regedit. If it fails, use "C:\Program Files\RustDesk\" as default.