### PR TITLE
This Pull Request addresses the dynamic detection of the RustDesk installation path and resolves several backward compatibility bugs on older Windows systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Tüm komut dosyaları Windows 7, 8.1, 10 ve 11'de test edilmiştir (PowerShell 2
 
 > **Güncelleme (v3.1):** T3Cabon adlı kullanıcının açtığı [#13 numaralı bildirim](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/13) referans alınarak, uzak bağlantı kopma sorunları çözülmüş; servis kapatma işlemleri konfigürasyon uygulama sonrasına taşınmıştır.
 
+> **Güncelleme (v3.2):** [#15 numaralı bildirim](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/15) referans alınarak, Windows 7 ve PowerShell 2.0 genel uyumluluk sorunları çözülmüş; 3. seçenek (Özel ID Belirleme) Windows 10 ve üzeri sistemlerle sınırlandırılmıştır.
+
 </details>
 
 <details>
@@ -75,6 +77,8 @@ This option completely clears the previously saved Private Server backup configu
 All scripts are tested on Windows 7 - 8.1 - 10 and 11 (PowerShell 2.0 fully compatible). Only "Custom ID Setting" (Option 3) requires Windows 10 and later due to OS limitations.
 
 > **Update (v3.1):** Thanks to the [#13 issue](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/13) raised by user T3Cabon, remote connection drop issues have been resolved; service termination operations are now executed after configuration is applied.
+
+> **Update (v3.2):** Thanks to the [#15 issue](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/15), general Windows 7 and PowerShell 2.0 compatibility issues have been resolved; Option 3 (Custom ID Setting) has been restricted to Windows 10 and later systems.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Bu seçenek ile RustDesk uzak bağlantı programının ID bilgisi otomatik olara
 Bu seçenek ile RustDesk uzak bağlantı programının ID bilgisi 9 haneli rastgele rakamlardan oluşturulacak bir değere dönüştürülür. Yeniden başlatmaya gerek yoktur.
 
 **3. "RustDesk ID'sini belirttiğiniz değere ayarlayın."**
-Bu seçenek ile RustDesk uzak bağlantı programının ID bilgisi tamamen kullanıcının belirteceği bir değere dönüştürülür. Yeniden başlatmaya gerek yoktur.
+Bu seçenek ile RustDesk uzak bağlantı programının ID bilgisi tamamen kullanıcının belirteceği bir değere dönüştürülür. Yeniden başlatmaya gerek yoktur. (Not: Bu seçenek yalnızca Windows 10 ve üzeri sistemlerde desteklenmektedir.)
 
 **4. "Public Sunucuya Geç (Özel Sunucu Bilgisini Temizle)"**
 Eğer aktif bir özel sunucu yapılandırmanız varsa, bu seçenek bu ayarları güvenli bir şekilde yedekler ve RustDesk'i varsayılan Public (Genel) sunuculara geçirir. Eğer zaten Public sunucudaysanız, hiçbir işlem yapmaz ve sizi uyarır.
@@ -37,7 +37,7 @@ Daha önce girilmiş hiçbir özel sunucu ayarınız yoksa veya yepyeni bir sunu
 **7. "Private Sunucu Yedeklerini Sil"**
 Bu seçenek, bilgisayarınızda daha önceden saklanmış olan özel sunucu (Private Server) yedek yapılandırma dosyalarını tamamen temizler. Sunucu adresinizi değiştirmek veya sistemde kayıtlı olan eski sunucu izlerini silip sıfırdan temiz bir kurulum yapmak istediğinizde kullanılır.
 
-Tüm komut dosyaları Windows 7, 8.1, 10 ve 11'de test edilmiştir (PowerShell 2.0 uyumlu).
+Tüm komut dosyaları Windows 7, 8.1, 10 ve 11'de test edilmiştir (PowerShell 2.0 tam uyumlu). Yalnızca "Özel ID Belirleme" (3. Seçenek) işletim sistemi kısıtlamalarından dolayı Windows 10 ve üzeri gerektirir.
 
 > **Güncelleme (v3.1):** T3Cabon adlı kullanıcının açtığı [#13 numaralı bildirim](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/13) referans alınarak, uzak bağlantı kopma sorunları çözülmüş; servis kapatma işlemleri konfigürasyon uygulama sonrasına taşınmıştır.
 
@@ -58,7 +58,7 @@ RustDesk ID information sometimes does not change after image deployment in comp
 With this option, the ID information of the RustDesk remote connection program will be converted into a value created from 9-digit random numbers. There is no need to reboot.
 
 **3. "Set the RustDesk ID to the value you specify"**
-With this option, the ID information of the RustDesk remote connection program will be converted to the value specified by the user. There is no need to reboot.
+With this option, the ID information of the RustDesk remote connection program will be converted to the value specified by the user. There is no need to reboot. (Note: This option is only supported on Windows 10 and later systems.)
 
 **4. "Set Public Server (Clear Custom Server Info)"**
 If you have a custom/private server configuration active, this option will back it up securely and switch RustDesk to the default Public servers. If you are already on the Public server, it will gracefully ignore the request.
@@ -72,7 +72,7 @@ If you don't have a backup or you want to define a brand-new Private Server, use
 **7. "Delete Private Server Backups"**
 This option completely clears the previously saved Private Server backup configuration files on your computer. It is very useful when you want to change your server address or completely remove the traces of the old server to start with a clean slate.
 
-All scripts are tested on Windows 7 - 8.1 - 10 and 11 (PowerShell 2.0 compatible).
+All scripts are tested on Windows 7 - 8.1 - 10 and 11 (PowerShell 2.0 fully compatible). Only "Custom ID Setting" (Option 3) requires Windows 10 and later due to OS limitations.
 
 > **Update (v3.1):** Thanks to the [#13 issue](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/13) raised by user T3Cabon, remote connection drop issues have been resolved; service termination operations are now executed after configuration is applied.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Tüm komut dosyaları Windows 7, 8.1, 10 ve 11'de test edilmiştir (PowerShell 2
 
 > **Güncelleme (v3.1):** T3Cabon adlı kullanıcının açtığı [#13 numaralı bildirim](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/13) referans alınarak, uzak bağlantı kopma sorunları çözülmüş; servis kapatma işlemleri konfigürasyon uygulama sonrasına taşınmıştır.
 
-> **Güncelleme (v3.2):** [#15 numaralı bildirim](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/15) referans alınarak, Windows 7 ve PowerShell 2.0 genel uyumluluk sorunları çözülmüş; 3. seçenek (Özel ID Belirleme) Windows 10 ve üzeri sistemlerle sınırlandırılmıştır.
+> **Güncelleme (v3.2):** [#15 numaralı bildirim](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/15) referans alınarak, RustDesk kurulum dizini artık doğrudan Windows Kayıt Defteri (Registry) üzerinden dinamik olarak tespit edilmektedir. Ayrıca bizim tarafımızdan tespit edilen Windows 7 ve PowerShell 2.0 genel uyumluluk sorunları da bu sürümde çözülmüş; 3. seçenek (Özel ID Belirleme) Windows 10 ve üzeri sistemlerle sınırlandırılmıştır.
 
 </details>
 
@@ -78,7 +78,7 @@ All scripts are tested on Windows 7 - 8.1 - 10 and 11 (PowerShell 2.0 fully comp
 
 > **Update (v3.1):** Thanks to the [#13 issue](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/13) raised by user T3Cabon, remote connection drop issues have been resolved; service termination operations are now executed after configuration is applied.
 
-> **Update (v3.2):** Thanks to the [#15 issue](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/15), general Windows 7 and PowerShell 2.0 compatibility issues have been resolved; Option 3 (Custom ID Setting) has been restricted to Windows 10 and later systems.
+> **Update (v3.2):** Thanks to the [#15 issue](https://github.com/abdullah-erturk/RustDesk-ID-Server-Changer/issues/15), the RustDesk installation directory is now dynamically detected via the Windows Registry. Additionally, general Windows 7 and PowerShell 2.0 compatibility issues (discovered internally) have been resolved; Option 3 (Custom ID Setting) has been restricted to Windows 10 and later systems.
 
 </details>
 

--- a/RustDesk_ID_Server_Changer.bat
+++ b/RustDesk_ID_Server_Changer.bat
@@ -117,7 +117,9 @@ echo.
 :ID_Host
 echo.
 echo $svc = Get-Service -Name RustDesk -ErrorAction SilentlyContinue > RustDesk_ID_Host.ps1
-echo $id = Get-Content "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" ^| Select-Object -Index 0 >> RustDesk_ID_Host.ps1
+echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_Host.ps1
+echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_Host.ps1
+echo $id = ^(Get-Content "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml"^)[0] >> RustDesk_ID_Host.ps1
 echo $hostname = hostname >> RustDesk_ID_Host.ps1
 echo Write-Host "Current ID: %rustdesk_id%" >> RustDesk_ID_Host.ps1
 echo $newId = "id = '$hostname'" >> RustDesk_ID_Host.ps1
@@ -125,8 +127,6 @@ echo Write-Host "New ID: $newId" >> RustDesk_ID_Host.ps1
 echo $fileContent = Get-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_Host.ps1
 echo $newContent = $fileContent -replace [regex]::Escape($id), $newId >> RustDesk_ID_Host.ps1
 echo $newContent ^| Set-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_Host.ps1
-echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_Host.ps1
-echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_Host.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_ID_Host.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_ID_Host.ps1
 start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
@@ -135,16 +135,16 @@ goto :done
 :ID_Random
 echo.
 echo $svc = Get-Service -Name RustDesk -ErrorAction SilentlyContinue > RustDesk_ID_Random.ps1
+echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_Random.ps1
+echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_Random.ps1
 echo $randomId = -join ((48..57) ^| Get-Random -Count 9 ^| ForEach-Object {[char]$_}) >> RustDesk_ID_Random.ps1
-echo $id = Get-Content "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" ^| Select-Object -Index 0 >> RustDesk_ID_Random.ps1
+echo $id = ^(Get-Content "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml"^)[0] >> RustDesk_ID_Random.ps1
 echo Write-Host "Current ID: %rustdesk_id%" >> RustDesk_ID_Random.ps1
 echo $newId = "id = '$randomId'" >> RustDesk_ID_Random.ps1
 echo Write-Host "New ID: $newId" >> RustDesk_ID_Random.ps1
 echo $fileContent = Get-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_Random.ps1
 echo $newContent = $fileContent -replace [regex]::Escape($id), $newId >> RustDesk_ID_Random.ps1
 echo $newContent ^| Set-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_Random.ps1
-echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_Random.ps1
-echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_Random.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_ID_Random.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_ID_Random.ps1
 start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
@@ -152,27 +152,69 @@ goto :done
 ::===============================================================================================================
 :ID_UserDefined
 echo.
+  ver | findstr /c:"Version 10." >nul
+  if errorlevel 1 (
+      if %LANG_TR%==1 (
+          echo Hata: Bu se‡enek sadece Windows 10 ve zeri srmlerde desteklenmektedir!
+      ) else (
+          echo Error: This option is only supported on Windows 10 and later!
+      )
+      timeout /t 5 >nul
+      goto :Main
+  )
 echo $svc = Get-Service -Name RustDesk -ErrorAction SilentlyContinue > RustDesk_ID_UserDefined.ps1
-echo $id = Get-Content "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" ^| Select-Object -Index 0 >> RustDesk_ID_UserDefined.ps1
-if %LANG_TR%==1 (
-echo YEN˜ RUSTDESK ID DE¦ERI EN AZ 6 KARAKTER OLMALIDIR
-timeout /t 2 >nul 2>&1
-echo.
-echo $newId = Read-Host "RustDesk ID Girin" >> RustDesk_ID_UserDefined.ps1
-) else (
-echo THE NEW RUSTDESK ID VALUE MUST BE AT LEAST 6 CHARACTERS
-timeout /t 2 >nul 2>&1
-echo.
-echo $newId = Read-Host "Enter RustDesk ID" >> RustDesk_ID_UserDefined.ps1
+echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_UserDefined.ps1
+echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_UserDefined.ps1
+echo $id = ^(Get-Content "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml"^)[0] >> RustDesk_ID_UserDefined.ps1
+  if %LANG_TR%==1 (
+  echo YENI RUSTDESK ID DEGERI EN AZ 6 KARAKTER OLMALIDIR
+  timeout /t 2 >nul 2>&1
+  echo.
+  goto Ask_ID_TR
+  ) else (
+  echo THE NEW RUSTDESK ID VALUE MUST BE AT LEAST 6 CHARACTERS
+  timeout /t 2 >nul 2>&1
+  echo.
+  goto Ask_ID_EN
+  )
+
+:Ask_ID_TR
+set "RUSTDESK_NEW_ID="
+set /p RUSTDESK_NEW_ID="RustDesk ID Girin (En az 6 karakter): "
+if not defined RUSTDESK_NEW_ID (
+    echo Hata: ID bos olamaz!
+    echo.
+    goto Ask_ID_TR
 )
-echo Write-Host "Current ID: %rustdesk_id%" >> RustDesk_ID_UserDefined.ps1
-echo $newId = "id = '$newId'" >> RustDesk_ID_UserDefined.ps1
+if "%RUSTDESK_NEW_ID:~5,1%"=="" (
+    echo Hata: ID en az 6 karakter olmalidir!
+    echo.
+    goto Ask_ID_TR
+)
+goto ID_UserDefined_Continue
+
+:Ask_ID_EN
+set "RUSTDESK_NEW_ID="
+set /p RUSTDESK_NEW_ID="Enter RustDesk ID (At least 6 characters): "
+if not defined RUSTDESK_NEW_ID (
+    echo Error: ID cannot be empty!
+    echo.
+    goto Ask_ID_EN
+)
+if "%RUSTDESK_NEW_ID:~5,1%"=="" (
+    echo Error: ID must be at least 6 characters!
+    echo.
+    goto Ask_ID_EN
+)
+goto ID_UserDefined_Continue
+
+:ID_UserDefined_Continue
+  echo Write-Host "Current ID: %rustdesk_id%" >> RustDesk_ID_UserDefined.ps1
+  echo $newId = "id = '%RUSTDESK_NEW_ID%'" >> RustDesk_ID_UserDefined.ps1
 echo Write-Host "New ID: $newId" >> RustDesk_ID_UserDefined.ps1
 echo $fileContent = Get-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_UserDefined.ps1
 echo $newContent = $fileContent -replace [regex]::Escape($id), $newId >> RustDesk_ID_UserDefined.ps1
 echo $newContent ^| Set-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_UserDefined.ps1
-echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_UserDefined.ps1
-echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_ID_UserDefined.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_ID_UserDefined.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_ID_UserDefined.ps1
 start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
@@ -197,6 +239,8 @@ if errorlevel 1 (
 del check_public.ps1 >nul 2>&1
 
 echo $svc = Get-Service -Name RustDesk -ErrorAction SilentlyContinue > RustDesk_Server_Public.ps1
+echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Public.ps1
+echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Public.ps1
 echo $paths = @("C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml", "$env:APPDATA\RustDesk\config\RustDesk2.toml") >> RustDesk_Server_Public.ps1
 echo foreach ($path in $paths) { >> RustDesk_Server_Public.ps1
 echo     if (Test-Path $path) { >> RustDesk_Server_Public.ps1
@@ -212,8 +256,6 @@ echo         $newContent = $newContent ^| Where-Object { $_.Trim() -ne "" } >> R
 echo         $newContent ^| Set-Content $path >> RustDesk_Server_Public.ps1
 echo     } >> RustDesk_Server_Public.ps1
 echo } >> RustDesk_Server_Public.ps1
-echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Public.ps1
-echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Public.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_Server_Public.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_Server_Public.ps1
 if errorlevel 3 (
@@ -264,13 +306,13 @@ if errorlevel 1 (
 del check_private.ps1 >nul 2>&1
 
 echo $svc = Get-Service -Name RustDesk -ErrorAction SilentlyContinue > RustDesk_Server_Private.ps1
+echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Private.ps1
+echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Private.ps1
 echo $paths = @("C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml", "$env:APPDATA\RustDesk\config\RustDesk2.toml") >> RustDesk_Server_Private.ps1
 echo foreach ($path in $paths) { >> RustDesk_Server_Private.ps1
 echo     $backupPath = "$path.backup" >> RustDesk_Server_Private.ps1
 echo     if (Test-Path $backupPath) { Copy-Item -Path $backupPath -Destination $path -Force } >> RustDesk_Server_Private.ps1
 echo } >> RustDesk_Server_Private.ps1
-echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Private.ps1
-echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Private.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_Server_Private.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_Server_Private.ps1
 start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
@@ -322,6 +364,8 @@ goto Server_Private_New_Proceed
 :Server_Private_New_Proceed
 echo.
 echo $svc = Get-Service -Name RustDesk -ErrorAction SilentlyContinue > RustDesk_Server_Private_New.ps1
+echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Private_New.ps1
+echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Private_New.ps1
 echo $paths = @("C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk2.toml", "$env:APPDATA\RustDesk\config\RustDesk2.toml") >> RustDesk_Server_Private_New.ps1
 echo foreach ($path in $paths) { >> RustDesk_Server_Private_New.ps1
 echo     if (Test-Path $path) { >> RustDesk_Server_Private_New.ps1
@@ -329,11 +373,10 @@ echo         $newContent = Get-Content $path >> RustDesk_Server_Private_New.ps1
 echo         $newContent = $newContent ^| Where-Object { $_.Trim() -ne "" } >> RustDesk_Server_Private_New.ps1
 echo         $newContent += "custom-rendezvous-server = '%RS_HOST%'" >> RustDesk_Server_Private_New.ps1
 echo         $newContent += "key = '%RS_KEY%'" >> RustDesk_Server_Private_New.ps1
+
 echo         $newContent ^| Set-Content $path >> RustDesk_Server_Private_New.ps1
 echo     } >> RustDesk_Server_Private_New.ps1
 echo } >> RustDesk_Server_Private_New.ps1
-echo if ($svc) { Stop-Service -Name RustDesk -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Private_New.ps1
-echo else { Stop-Process -Name "rustdesk" -Force -ErrorAction SilentlyContinue; Start-Sleep -Seconds 1 } >> RustDesk_Server_Private_New.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_Server_Private_New.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_Server_Private_New.ps1
 start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray

--- a/RustDesk_ID_Server_Changer.bat
+++ b/RustDesk_ID_Server_Changer.bat
@@ -129,7 +129,7 @@ echo $newContent = $fileContent -replace [regex]::Escape($id), $newId >> RustDes
 echo $newContent ^| Set-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_Host.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_ID_Host.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_ID_Host.ps1
-start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
+start "" "%RUSTDESK_PATH%\rustdesk.exe" --tray
 goto :done
 ::===============================================================================================================
 :ID_Random
@@ -147,7 +147,7 @@ echo $newContent = $fileContent -replace [regex]::Escape($id), $newId >> RustDes
 echo $newContent ^| Set-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_Random.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_ID_Random.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_ID_Random.ps1
-start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
+start "" "%RUSTDESK_PATH%\rustdesk.exe" --tray
 goto :done
 ::===============================================================================================================
 :ID_UserDefined
@@ -217,7 +217,7 @@ echo $newContent = $fileContent -replace [regex]::Escape($id), $newId >> RustDes
 echo $newContent ^| Set-Content -Path "C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\RustDesk\config\RustDesk.toml" >> RustDesk_ID_UserDefined.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_ID_UserDefined.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_ID_UserDefined.ps1
-start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
+start "" "%RUSTDESK_PATH%\rustdesk.exe" --tray
 goto :done
 ::===============================================================================================================
 :Server_Public
@@ -266,7 +266,7 @@ if errorlevel 3 (
     )
     goto :done
 )
-start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
+start "" "%RUSTDESK_PATH%\rustdesk.exe" --tray
 echo.
 if %LANG_TR%==1 (
 echo Mevcut private sunucu ayarlarç yedeklendi ve Public sunucuya geáildi.
@@ -315,7 +315,7 @@ echo     if (Test-Path $backupPath) { Copy-Item -Path $backupPath -Destination $
 echo } >> RustDesk_Server_Private.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_Server_Private.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_Server_Private.ps1
-start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
+start "" "%RUSTDESK_PATH%\rustdesk.exe" --tray
 echo.
 if %LANG_TR%==1 (
 echo Yedeklenen Private Sunucu ayarlarç geri yÅklendi.
@@ -379,7 +379,7 @@ echo     } >> RustDesk_Server_Private_New.ps1
 echo } >> RustDesk_Server_Private_New.ps1
 echo if ($svc) { Start-Service -Name RustDesk -ErrorAction SilentlyContinue } >> RustDesk_Server_Private_New.ps1
 powershell.exe -ExecutionPolicy Bypass -File RustDesk_Server_Private_New.ps1
-start "" "C:\Program Files\RustDesk\rustdesk.exe" --tray
+start "" "%RUSTDESK_PATH%\rustdesk.exe" --tray
 echo.
 if %LANG_TR%==1 (
 echo Yeni Private Sunucu baüarçyla tançmlandç ve RustDesk yeniden baülatçldç.


### PR DESCRIPTION
**Key Updates:**
- **Dynamic Path Detection (Resolves #15):** The script now dynamically retrieves the RustDesk installation directory directly from the Windows Registry (`HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RustDesk`) rather than relying on a hardcoded `C:\Program Files\` path. It also includes 32-bit/64-bit fallbacks.
- **PowerShell 2.0 Compatibility:** Replaced `Select-Object -Index 0` with array indexing `[0]` to prevent `$null` assignment bugs on systems running PowerShell 2.0 (like Windows 7 and 8.1), ensuring the configuration file is safely modified across all options.
- **Robust Custom ID Input (Option 3):** Replaced the problematic `Read-Host` PowerShell command with native batch `set /p` for capturing the custom ID. Added strict variable validation (`if not defined`) to prevent configuration corruption if the user accidentally submits an empty string.
- **OS Restriction for Option 3:** Due to inherent limitations with some older Windows environments processing the Custom ID loop, Option 3 has been safely restricted to **Windows 10 and later**. A friendly warning is now displayed for unsupported OS versions.